### PR TITLE
Add PDF scan support by improving the Azure Logic App

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ In this implementation, Azure OpenAI `gpt-4o` is used instead.
 Also see this [blog post](https://raffertyuy.com/raztype/handwriting-to-second-brain-gpt/)
 
 ## Solution Flow
-This solution will:
-
-- Watch for new files in a specific OneDrive folder (using Azure Logic Apps)
-- Process the files using GPT-4o (through a Function App)
-- Copy the image and save a new markdown file output in a destination OneDrive folder.
+This solution is using Azure Logic Apps with the following flow:
+1. Watch for new files in a specific OneDrive folder
+2. Check for GPT-4o supported image formats
+  - if the filetype is PDF, convert to JPG using [OneDrive - Convert File](https://learn.microsoft.com/en-us/connectors/onedrive/#convert-file-(preview)) (limited to the first page of the PDF file).
+  - if the filetype is not supported, skip.
+3. Extract the text from the image file using GPT-4o (through a Function App).
+4. Copy the image and save a new markdown file output in a destination OneDrive folder.
 
 ```mermaid
 flowchart LR
@@ -34,22 +36,6 @@ flowchart LR
     end
     Output --> |save| MD[Markdown File<br />in OneDrive]
 ```
-
-## Limitations / TODOs
-- [ ] GPT-4o only accepts image files. Add error handling for unsupported file types.
-- [ ] Add a new Azure Function for converting PDF to image files using this sample code (with revisions to save individual image files to OneDrive)
-    ```python
-    # import module
-    from pdf2image import convert_from_path
-
-    # Store Pdf with convert_from_path function
-    images = convert_from_path('example.pdf')
-
-    for i in range(len(images)):
-        # Save pages as images in the pdf
-        images[i].save('page'+ str(i) +'.jpg', 'JPEG')
-    ```
-- [ ] Using [Prompt Flow](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/prompt-flow) for better tracing and evaluation of prompts.
 
 > [!NOTE]
 > Prompt Flow was previously attempted, but the following gaps were encountered (as of 2024-06-28):
@@ -101,5 +87,5 @@ Since we're passing a OneDrive file to Azure Functions as a `multipart/form-data
 > Since I'm using Obsidian for my second brain, my final markdown image link uses `![[image_path]]` instead of the standard `![name](image_path)` format.
 
 ### Deployment
-- `code.json` is the copy-paste from the Logic Apps's code view that I personally use, after building with the Logic App designer.
+- `code.json` is the copy-pasted code from the Logic Apps's code view, for reference. This is the exact code that I personally use after using the Logic App designer.
 - `azuredeploy.json` is the ARM template to be deployed to azure, generated from the resource group's "export template"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Also see this [blog post](https://raffertyuy.com/raztype/handwriting-to-second-b
 This solution is using Azure Logic Apps with the following flow:
 1. Watch for new files in a specific OneDrive folder
 2. Check for GPT-4o supported image formats
-  - if the filetype is PDF, convert to JPG using [OneDrive - Convert File](https://learn.microsoft.com/en-us/connectors/onedrive/#convert-file-(preview)) (limited to the first page of the PDF file).
-  - if the filetype is not supported, skip.
+   - if the filetype is PDF, convert to JPG using [OneDrive - Convert File](https://learn.microsoft.com/en-us/connectors/onedrive/#convert-file-(preview)) (limited to the first page of the PDF file).
+   - if the filetype is not supported, skip.
 3. Extract the text from the image file using GPT-4o (through a Function App).
 4. Copy the image and save a new markdown file output in a destination OneDrive folder.
 

--- a/az-function/prompts/extractMainTitle.txt
+++ b/az-function/prompts/extractMainTitle.txt
@@ -1,33 +1,67 @@
 Extract the main title for these notes
 - Respond with the title only.
-- The title should be in a format that can be a Windows OS filename. If there are special characters that can't be a filename, remove them.
+- The title should be in a format that can be a Windows OS filename. If there are Illegal Filename Characters in the title, remove them.
 - If there is no title, respond with "NONE".
 - The title be prefixed with a date stamp in YYYYMMDD format.
 - If there is a date stamp but in the wrong format, reformat to YYYYMMDD.
 - If there is no date stamp, add a prefix "{DateStamp}"
 
-## Example 1:
-- Original Title: "My Notes"
-- Output Title: "{DateStamp} My Notes"
+## Illegal Filename Characters
+# pound
+% percent
+& ampersand
+{ left curly bracket
+} right curly bracket
+\ back slash
+< left angle bracket
+> right angle bracket
+* asterisk
+? question mark
+/ forward slash
+$ dollar sign
+! exclamation point
+' single quotes
+" double quotes
+: colon
+@ at sign
++ plus sign
+` backtick
+| pipe
+= equal sign
+emojis
+alt codes
 
-## Example 2:
-- Original Title: "20240501 My Notes"
-- Output Title: "20240501 My Notes"
+## Examples
+### Example 1:
+- Original Title: My Notes
+- Output Title: {DateStamp} My Notes
 
-## Example 3:
-- Original Title: "2024-05-01 My Notes"
-- Output Title: "20240501 My Notes"
+### Example 2:
+- Original Title: 20240501 My Notes
+- Output Title: 20240501 My Notes
 
-## Example 4:
-- Original Title: "20240501-1535 My Notes"
-- Output Title: "20240501-1535 My Notes"
+### Example 3:
+- Original Title: 2024-05-01 My Notes!
+- Output Title: 20240501 My Notes
 
-## Example 5:
-- Original Title: "2024-05-01 15:35 My Notes"
-- Output Title: "20240501 1535 My Notes"
+### Example 4:
+- Original Title: 20240501-1535 My Notes!
+- Output Title: 20240501-1535 My Notes
 
-## Example 6:
+### Example 5:
+- Original Title: '2024-05-01 15:35 My Notes'
+- Output Title: 20240501 1535 My Notes
+
+### Example 6:
+- Original Title: ## My Notes
+- Output Title: {DateStamp} My Notes
+
+### Example 7:
 - Original Title: "## My Notes"
-- Output Title: "{DateStamp} My Notes"
+- Output Title: {DateStamp} My Notes
+
+### Example 8:
+- Original Title: "## My Notes | Part 1"
+- Output Title: {DateStamp} My Notes Part 1
 
 Revalidate and think step by step.

--- a/az-logicapp/azuredeploy.json
+++ b/az-logicapp/azuredeploy.json
@@ -37,7 +37,7 @@
           "name": "[parameters('connections_keyvault_name')]",
           "displayName": "Azure Key Vault",
           "description": "Azure Key Vault is a service to securely store and access secrets.",
-          "iconUri": "[concat('https://connectoricons-prod.azureedge.net/releases/v1.0.1694/1.0.1694.3752/', parameters('connections_keyvault_name'), '/icon.png')]",
+          "iconUri": "[concat('https://connectoricons-prod.azureedge.net/u/jayawan/releases/v1.0.1694/1.0.1694.3753/', parameters('connections_keyvault_name'), '/icon.png')]",
           "brandColor": "#0079d6",
           "id": "[concat('/subscriptions/',subscription().subscriptionId,'/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/',parameters('connections_keyvault_name'))]",
           "type": "Microsoft.Web/locations/managedApis"
@@ -107,18 +107,17 @@
             }
           },
           "triggers": {
-            "When_a_file_is_created": {
+            "When_a_file_is_modified": {
               "recurrence": {
-                "frequency": "Minute",
-                "interval": 5
+                "interval": 3,
+                "frequency": "Minute"
               },
               "evaluatedRecurrence": {
-                "frequency": "Minute",
-                "interval": 5
+                "interval": 3,
+                "frequency": "Minute"
               },
               "metadata": {
-                "A8546FE4B5BBEFDD!93368": "/Handwritten Notes",
-                "6e202211-2856-4d17-9ded-5beb8b8626b0": "/"
+                "A8546FE4B5BBEFDD!93368": "/Handwritten Notes"
               },
               "type": "ApiConnection",
               "inputs": {
@@ -128,11 +127,12 @@
                   }
                 },
                 "method": "get",
-                "path": "/datasets/default/triggers/onnewfilev2",
+                "path": "/datasets/default/triggers/onupdatedfilev2",
                 "queries": {
                   "folderId": "A8546FE4B5BBEFDD!93368",
-                  "includeSubfolders": true,
+                  "includeSubfolders": false,
                   "inferContentType": true,
+                  "includeFileContent": true,
                   "simulate": false
                 }
               }
@@ -151,7 +151,7 @@
                   }
                 },
                 "method": "post",
-                "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(triggerOutputs()['headers']['x-ms-file-id']))}/copy",
+                "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/copy",
                 "queries": {
                   "destination": "/second-brain/second-brain/_fleeting-notes/@{body('Parse_JSON_-_Get_ExtractNotes_Response')?['extractedTitle']}.@{variables('imageFileExtension')}",
                   "overwrite": true
@@ -233,7 +233,7 @@
                     {
                       "body": "@triggerBody()",
                       "headers": {
-                        "Content-Disposition": "form-data; name=image; filename=\"@{triggerOutputs()['headers']['x-ms-file-name-encoded']}\"",
+                        "Content-Disposition": "form-data; name=image; filename=\"@{body('Get_file_metadata')?['Name']}\"",
                         "Content-Type": "@{triggerOutputs()['headers']['Content-Type']}"
                       }
                     }
@@ -248,7 +248,7 @@
             },
             "Get_Functions_Secret": {
               "runAfter": {
-                "Initialize_variable_-_imageFileExtension": ["Succeeded"]
+                "Check_if_Supported_Image": ["Succeeded"]
               },
               "type": "ApiConnection",
               "inputs": {
@@ -280,6 +280,152 @@
                   }
                 ]
               }
+            },
+            "Check_if_Supported_Image": {
+              "actions": {},
+              "runAfter": {
+                "Initialize_variable_-_imageFileExtension": ["Succeeded"]
+              },
+              "else": {
+                "actions": {
+                  "Check_if_PDF": {
+                    "actions": {
+                      "Convert_file": {
+                        "type": "ApiConnection",
+                        "inputs": {
+                          "host": {
+                            "connection": {
+                              "name": "@parameters('$connections')['onedrive']['connectionId']"
+                            }
+                          },
+                          "method": "get",
+                          "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/convert",
+                          "queries": {
+                            "type": "JPG"
+                          }
+                        }
+                      },
+                      "Terminate_-_Skip": {
+                        "runAfter": {
+                          "Move_converted_file": ["Succeeded"]
+                        },
+                        "type": "Terminate",
+                        "inputs": {
+                          "runStatus": "Cancelled"
+                        }
+                      },
+                      "Create_JPG_file": {
+                        "runAfter": {
+                          "Convert_file": ["Succeeded"]
+                        },
+                        "type": "ApiConnection",
+                        "inputs": {
+                          "host": {
+                            "connection": {
+                              "name": "@parameters('$connections')['onedrive']['connectionId']"
+                            }
+                          },
+                          "method": "post",
+                          "body": "@body('Convert_file')",
+                          "path": "/datasets/default/files",
+                          "queries": {
+                            "folderPath": "/Handwritten Notes",
+                            "name": "@{body('Get_file_metadata')?['NameNoExt']}.jpg"
+                          }
+                        },
+                        "runtimeConfiguration": {
+                          "contentTransfer": {
+                            "transferMode": "Chunked"
+                          }
+                        }
+                      },
+                      "Move_converted_file": {
+                        "runAfter": {
+                          "Create_JPG_file": ["Succeeded"]
+                        },
+                        "type": "ApiConnection",
+                        "inputs": {
+                          "host": {
+                            "connection": {
+                              "name": "@parameters('$connections')['onedrive']['connectionId']"
+                            }
+                          },
+                          "method": "post",
+                          "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/move",
+                          "queries": {
+                            "destination": "/Handwritten Notes/processed/@{body('Get_file_metadata')?['Name']}",
+                            "overwrite": true
+                          }
+                        }
+                      }
+                    },
+                    "else": {
+                      "actions": {
+                        "Terminate_-_Unsupported": {
+                          "type": "Terminate",
+                          "inputs": {
+                            "runStatus": "Failed",
+                            "runError": {
+                              "code": "400",
+                              "message": "Image type is not supported. Supported types: jpg, gif, png, bmp, tiff."
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "expression": {
+                      "and": [
+                        {
+                          "equals": ["", ""]
+                        }
+                      ]
+                    },
+                    "type": "If"
+                  }
+                }
+              },
+              "expression": {
+                "or": [
+                  {
+                    "equals": ["@variables('imageFileExtension')", "jpg"]
+                  },
+                  {
+                    "equals": ["@variables('imageFileExtension')", "jpeg"]
+                  },
+                  {
+                    "equals": ["@variables('imageFileExtension')", "png"]
+                  },
+                  {
+                    "equals": ["@variables('imageFileExtension')", "gif"]
+                  },
+                  {
+                    "equals": ["@variables('imageFileExtension')", "bmp"]
+                  },
+                  {
+                    "equals": ["@variables('imageFileExtension')", "tiff"]
+                  }
+                ]
+              },
+              "type": "If"
+            },
+            "Move_Processed_File": {
+              "runAfter": {
+                "Create_markdown_file": ["Succeeded"]
+              },
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['onedrive']['connectionId']"
+                  }
+                },
+                "method": "post",
+                "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/move",
+                "queries": {
+                  "destination": "/Handwritten Notes/processed/@{body('Get_file_metadata')?['Name']}",
+                  "overwrite": true
+                }
+              }
             }
           },
           "outputs": {}
@@ -289,7 +435,7 @@
             "value": {
               "onedrive": {
                 "id": "[concat('/subscriptions/',subscription().subscriptionId,'/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/onedrive')]",
-                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('connections_onedrive_name'))]",
+                "connectionId": "[resourceId('Microsoft.Web/c`onnections', parameters('connections_onedrive_name'))]",
                 "connectionName": "onedrive"
               },
               "keyvault": {

--- a/az-logicapp/code.json
+++ b/az-logicapp/code.json
@@ -2,6 +2,162 @@
     "definition": {
         "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
         "actions": {
+            "Check_if_Supported_Image": {
+                "actions": {},
+                "else": {
+                    "actions": {
+                        "Check_if_PDF": {
+                            "actions": {
+                                "Convert_file": {
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['onedrive']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/convert",
+                                        "queries": {
+                                            "type": "JPG"
+                                        }
+                                    },
+                                    "type": "ApiConnection"
+                                },
+                                "Create_JPG_file": {
+                                    "inputs": {
+                                        "body": "@body('Convert_file')",
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['onedrive']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/datasets/default/files",
+                                        "queries": {
+                                            "folderPath": "/Handwritten Notes",
+                                            "name": "@{body('Get_file_metadata')?['NameNoExt']}.jpg"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Convert_file": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "runtimeConfiguration": {
+                                        "contentTransfer": {
+                                            "transferMode": "Chunked"
+                                        }
+                                    },
+                                    "type": "ApiConnection"
+                                },
+                                "Move_converted_file": {
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['onedrive']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/move",
+                                        "queries": {
+                                            "destination": "/Handwritten Notes/processed/@{body('Get_file_metadata')?['Name']}",
+                                            "overwrite": true
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Create_JPG_file": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ApiConnection"
+                                },
+                                "Terminate_-_Skip": {
+                                    "inputs": {
+                                        "runStatus": "Cancelled"
+                                    },
+                                    "runAfter": {
+                                        "Move_converted_file": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Terminate"
+                                }
+                            },
+                            "else": {
+                                "actions": {
+                                    "Terminate_-_Unsupported": {
+                                        "inputs": {
+                                            "runError": {
+                                                "code": "400",
+                                                "message": "Image type is not supported. Supported types: jpg, gif, png, bmp, tiff."
+                                            },
+                                            "runStatus": "Failed"
+                                        },
+                                        "type": "Terminate"
+                                    }
+                                }
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "equals": [
+                                            "",
+                                            ""
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "If"
+                        }
+                    }
+                },
+                "expression": {
+                    "or": [
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "jpg"
+                            ]
+                        },
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "jpeg"
+                            ]
+                        },
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "png"
+                            ]
+                        },
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "gif"
+                            ]
+                        },
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "bmp"
+                            ]
+                        },
+                        {
+                            "equals": [
+                                "@variables('imageFileExtension')",
+                                "tiff"
+                            ]
+                        }
+                    ]
+                },
+                "runAfter": {
+                    "Initialize_variable_-_imageFileExtension": [
+                        "Succeeded"
+                    ]
+                },
+                "type": "If"
+            },
             "Copy_file": {
                 "inputs": {
                     "host": {
@@ -10,7 +166,7 @@
                         }
                     },
                     "method": "post",
-                    "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(triggerOutputs()['headers']['x-ms-file-id']))}/copy",
+                    "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/copy",
                     "queries": {
                         "destination": "/second-brain/second-brain/_fleeting-notes/@{body('Parse_JSON_-_Get_ExtractNotes_Response')?['extractedTitle']}.@{variables('imageFileExtension')}",
                         "overwrite": true
@@ -61,7 +217,7 @@
                     "path": "/secrets/@{encodeURIComponent('razpython-defaulthostkey')}/value"
                 },
                 "runAfter": {
-                    "Initialize_variable_-_imageFileExtension": [
+                    "Check_if_Supported_Image": [
                         "Succeeded"
                     ]
                 },
@@ -95,7 +251,7 @@
                             {
                                 "body": "@triggerBody()",
                                 "headers": {
-                                    "Content-Disposition": "form-data; name=image; filename=\"@{triggerOutputs()['headers']['x-ms-file-name-encoded']}\"",
+                                    "Content-Disposition": "form-data; name=image; filename=\"@{body('Get_file_metadata')?['Name']}\"",
                                     "Content-Type": "@{triggerOutputs()['headers']['Content-Type']}"
                                 }
                             }
@@ -133,6 +289,27 @@
                 },
                 "type": "InitializeVariable"
             },
+            "Move_Processed_File": {
+                "inputs": {
+                    "host": {
+                        "connection": {
+                            "name": "@parameters('$connections')['onedrive']['connectionId']"
+                        }
+                    },
+                    "method": "post",
+                    "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent(body('Get_file_metadata')?['Id']))}/move",
+                    "queries": {
+                        "destination": "/Handwritten Notes/processed/@{body('Get_file_metadata')?['Name']}",
+                        "overwrite": true
+                    }
+                },
+                "runAfter": {
+                    "Create_markdown_file": [
+                        "Succeeded"
+                    ]
+                },
+                "type": "ApiConnection"
+            },
             "Parse_JSON_-_Get_ExtractNotes_Response": {
                 "inputs": {
                     "content": "@body('HTTP_-_Extract_Notes')",
@@ -168,10 +345,10 @@
             }
         },
         "triggers": {
-            "When_a_file_is_created": {
+            "When_a_file_is_modified": {
                 "evaluatedRecurrence": {
                     "frequency": "Minute",
-                    "interval": 1
+                    "interval": 3
                 },
                 "inputs": {
                     "host": {
@@ -180,21 +357,21 @@
                         }
                     },
                     "method": "get",
-                    "path": "/datasets/default/triggers/onnewfilev2",
+                    "path": "/datasets/default/triggers/onupdatedfilev2",
                     "queries": {
                         "folderId": "A8546FE4B5BBEFDD!93368",
-                        "includeSubfolders": true,
+                        "includeFileContent": true,
+                        "includeSubfolders": false,
                         "inferContentType": true,
                         "simulate": false
                     }
                 },
                 "metadata": {
-                    "6e202211-2856-4d17-9ded-5beb8b8626b0": "/",
                     "A8546FE4B5BBEFDD!93368": "/Handwritten Notes"
                 },
                 "recurrence": {
                     "frequency": "Minute",
-                    "interval": 1
+                    "interval": 3
                 },
                 "type": "ApiConnection"
             }


### PR DESCRIPTION
The change primarily uses Azure Logic App's OneDrive connector - Convert File action.
This action has a limitation of processing the first page of the PDF file only, but that is enough for this use case.

Changes to `README.md`:

* The solution flow has been updated to include checks for supported image formats and steps for handling unsupported file types. If the file type is PDF, it is converted to JPG. Unsupported file types are skipped.
* The limitations section has been removed from the README.
* The description of the deployment process has been refined for clarity.

Changes to `az-function/prompts/extractMainTitle.txt`:

* The instructions for extracting the main title have been updated. The instructions now include a list of illegal filename characters that should be removed from the title. The examples have also been updated to reflect these changes.

Changes to `az-logicapp/azuredeploy.json`:

* The Azure Logic Apps flow has been updated to trigger when a file is modified instead of when a file is created. The recurrence interval has been reduced from 5 minutes to 3 minutes.
* The path has been updated to trigger on an updated file instead of a new file. The flow now does not include subfolders and includes file content.
* The path for copying the image has been updated to use the metadata from the 'Get file metadata' action.
* The 'Content-Disposition' header in the 'ExtractNotes' action has been updated to use the name from the 'Get file metadata' action.
* A new 'Check if Supported Image' action has been added to the flow. This action checks if the file is an image and if it is a supported format. If the file is a PDF, it is converted to JPG. If the file is not a supported image format, the flow is terminated.
* A new 'Move Processed File' action has been added to the flow. This action moves the processed file to a 'processed' folder in OneDrive.